### PR TITLE
Respeccify & import readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: Check Respec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: w3c/spec-prod@v2

--- a/LICENSE-CC-BY-4.0
+++ b/LICENSE-CC-BY-4.0
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# CACAO-ZCAP
+
+Integration of [CAIP-74: Chain-Agnostic Capability Objects (CACAO)][CACAO]
+with [Authorization Capabilities for Linked Data (ZCAP)][ZCAP].
+
+View the rendered specification draft document:
+https://demo.didkit.dev/2022/cacao-zcap/ ([Source](./index.html))
+
+## License
+
+Creative Commons Attribution 4.0 International License ([LICENSE-CC-BY-4.0](LICENSE-CC-BY-4.0) or https://creativecommons.org/licenses/by/4.0/)
+
+[CACAO]: https://github.com/ukstv/CAIPs/blob/0a57efa129001719189f05595d65a65a8b36dfc2/CAIPs/caip-74.md
+[ZCAP]: https://github.com/w3c-ccg/zcap-spec/

--- a/index.html
+++ b/index.html
@@ -502,5 +502,33 @@ CACAO request ID (CACAO payload "requestId" value).
 
   </section>
 
+  <section class="informative">
+    <h2>Security Considerations</h2>
+
+    <section class="informative">
+      <h3>Content in zCap not included in CACAO</h3>
+      <p>
+Certain properties of the zCap delegation and proof object do not appear in the
+CACAO object but are synthesized as part of the [[[#cacao-zcap-mapping]]]. In
+particular, the delegation type property with value <code>CacaoZcap2022</code>,
+proof type property with value <code>CacaoZcapProof2022</code>, and proof
+<code>proofPurpose</code> property with value
+<code>capabilityDelegation</code>. Other properties are passed through from the
+CACAO into the delegation/proof but with different property names, which may
+have different meanings, e.g. <code>iss</code> as
+<code>verificationMethod</code>, and <code>iat</code> as <code>created</code>.
+It is possible therefore that an entity may sign/create a CACAO without
+intending it to be used as
+<code>CacaoZcap2022</code>/<code>CacaoZcapProof2022</code> or realizing that it
+may be used as such. Applications may want to pay close attention to the
+CACAO-ZCAP statement substring (<code>cacaoZcapSubstatement</code>) - which is
+expected to be seen by the user during signing - for determining how much to
+rely on a <code>CacaoZcap2022</code>/<code>CacaoZcapProof2022</code> for
+authorization/delegation purposes.
+      </p>
+    </section>
+
+  </section>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -99,13 +99,14 @@
   <section id="context">
     <h2>Context</h2>
     <p>
-<a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file: <a
-href="https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json">https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json</a>
+This specification defines the following
+<a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file:
+<a href="contexts/v1.json">https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json</a>
     </p>
     <p>
-This context file is expected to be used in <code>@context</code> following the
+JSON-LD documents using <a href="#CacaoZcap2022">CacaoZcap2022</a> and <a href="#CacaoZcapProof2022">CacaoZcapProof2022</a> are expected to use this context file in <code>@context</code> following the
 [[SECURITY-VOCABULARY]] context
-(<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>). i.e.:
+(<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>), i.e.:
     </p>
     <pre>
 {
@@ -295,12 +296,13 @@ id of the delegation object.
       <h3>issuer-verificationMethod mapping</h3>
       <p>
 The CACAO payload issuer property (<code>p.iss</code>) is defined by [[CACAO]]
-to be a [[DID-PKH]] DID. The proof
-<a href="https://www.w3.org/TR/did-core/#dfn-verificationmethod"><code>verificationMethod</code></a>
+to be a [[DID-PKH]] <a data-cite="DID-CORE#dfn-decentralized-identifiers">DID</a>. The proof
+<a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verificationmethod">verificationMethod</a>
 property is expected to be a
-<a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL</a> resolving to
-a <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-methods">verification method</a>.
-CACAO-ZCAP converts between these two fields by assuming that the issuer DID
+<a data-cite="DID-CORE#did-url-syntax">DID URL</a> resolving to
+a <a data-cite="DID-CORE#verification-methods">verification method map</a>.
+CACAO-ZCAP converts between these two fields (CACAO issuer and verification
+method URL) by assuming that the issuer DID
 has a <em>default verification method</em>, that the CACAO signature is created
 using the
 <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-material">verification material</a>
@@ -375,24 +377,26 @@ substmt-opt      = [ ": " substatement ]
 actions          = action *( ", " action )
 action           = *( reserved / unreserved / " " )
 substatement     = *( reserved / unreserved / " " )
-	</pre>
-        <p>The <code>substatement</code> is the value of the <a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a> proof property if present.</p>
-        <p>The <code>action</code> values are represented in the proof's <code>allowedAction</code> property as follows:</p>
-        <ul>
-          <li><code>allowedAction</code> is omitted when the <code>stmt-noaction</code> production is matched.</li>
-          <li><code>allowedAction</code> is an array of <code>action</code> strings when the <code>stmt-actions</code> production is matched.</li>
-        </ul>
+      </pre>
+      <p>The <code>substatement</code> is the value of the <a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a> proof property if present.</p>
+      <p>The <code>action</code> values are represented in the proof's <code>allowedAction</code> property as follows:</p>
+      <ul>
+        <li><code>allowedAction</code> is omitted when the <code>stmt-noaction</code> production is matched.</li>
+        <li><code>allowedAction</code> is an array of <code>action</code> strings when the <code>stmt-actions</code> production is matched.</li>
+      </ul>
     </section>
 
   </section>
 
-  <section id="terms">
-    <h2>Terms</h2>
+  <section id="vocabulary">
+    <h2>CACAO-ZCAP Vocabulary</h2>
     <p>
 This document defines the following terms, in the namespace
 <code>https://demo.didkit.dev/2022/cacao-zcap/#</code>.
     </p>
-
+    <p>
+In JSON-LD, these terms may be imported using [[[#context]]].
+    </p>
     <section id="CacaoZcap2022">
       <h3>CacaoZcap2022</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -4,34 +4,102 @@
 	<title>CACAO-ZCAP</title>
 	<meta charset=utf-8>
 	<style>
-section:target {
-	outline: .5ex solid #ff9;
-}
 .mapping-table td:nth-child(2) {
 	text-align: center;
 }
 	</style>
+	<script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+	<script class="remove">
+	  // https://respec.org/docs/
+	  const respecConfig = {
+	    shortName: "cacao-zcap",
+	    specStatus: "unofficial",
+	    edDraftURI: "https://demo.didkit.dev/2022/cacao-zcap/",
+	    editors: [
+	      {
+		name: "Charles E. Lehner", url: "https://www.w3.org/wiki/User:Cel",
+		company: "Spruce", companyURL: "https://spruceid.com/",
+		w3cid: 124982
+	      }
+	    ],
+	    subtitle: "Chain-Agnostic CApability Objects (CACAOs) as Authorization Capabilities (zCaps)",
+	    group: "credentials",
+	    wgPublicList: "public-credentials",
+	    github: {
+	      repoURL: "spruceid/cacao-zcap",
+	      branch: "main"
+	    },
+	    localBiblio: {
+	      "MULTIBASE": {
+		title: "The Multibase Encoding Scheme",
+		date: "February 2022",
+		href: "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-05",
+		authors: ["Juan Benet", "Manu Sporny"],
+		status: "Internet-Draft",
+		publisher: "IETF"
+	      },
+	      "SECURITY-VOCABULARY": {
+		title: "Security Linked Data Vocabulary",
+		href: "https://w3id.org/security",
+		authors: ["Manu Sporny", "David Longley"],
+		status: "CGDRAFT",
+		publisher: "Web Payments Community Group",
+	      },
+	      "DATA-INTEGRITY": {
+		title: "Data Integrity",
+		href: "https://w3c-ccg.github.io/data-integrity-spec/",
+		authors: ["David Longley", "Manu Sporny"],
+		status: "CGDRAFT",
+		publisher: "Credentials Community Group",
+	      },
+	      "ZCAP": {
+		title:    "Authorization Capabilities for Linked Data v0.3",
+		href:     "https://w3c-ccg.github.io/zcap-spec/",
+		status:   "CGDRAFT",
+		authors: ["Christopher Lemmer Webber", "Manu Sporny", "Mark S. Miller"],
+		publisher:  "Credentials Community Group"
+	      },
+	      "CACAO": {
+		title: "CACAO: Chain Agnostic CApability Object",
+		href: "https://github.com/ChainAgnostic/CAIPs/blob/91aaaff73038c2629ff11b88c2209f61521d8ece/CAIPs/caip-74.md",
+		authors: ["Sergey Ukustov"],
+                publisher: "CASA",
+		date: "March 2022"
+	      },
+	      "DAG-CBOR": {
+	        title: "DAG-CBOR: CBOR IPLD format",
+		href: "https://ipld.io/specs/codecs/dag-cbor/spec/",
+		authors: ["Rod Vagg", "Volker Mische", "Mikeal Rogers"],
+		status: "Descriptive - Draft",
+                publisher: "IPLD",
+		date: "August 2019"
+	      },
+	      "DID-PKH": {
+	        title: "The did:pkh Method",
+                href: "https://github.com/w3c-ccg/did-pkh/blob/ea93b0a5e0e8b54e572f3a6ca5a294f147901d2d/did-pkh-method-draft.md",
+		authors: ["Wayne Chang", "Charles Lehner", "Juan Caballero", "Joel Thorstensson"],
+                status: "W3C Community Group Draft",
+                publisher: "W3C Credentials Community Group",
+		date: "February 2022"
+	      }
+	    }
+	  };
+	</script>
 </head>
 <body>
-	<h1>CACAO-ZCAP</h1>
-	<h2>Integration of CACAO with ZCAP</h2>
-	<p>This document: <a href="https://demo.didkit.dev/2022/cacao-zcap/">https://demo.didkit.dev/2022/cacao-zcap/</a></p>
-	<p>Source: <a href="https://github.com/spruceid/cacao-zcap">https://github.com/spruceid/cacao-zcap</a></p>
-	<p>This document is licensed under a <a ref="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-
 	<section id="abstract">
-	<h2><a href="#abstract">Abstract</a></h2>
 	</section>
 
 	<section id="sotd">
-	<h2><a href="#sotd">Status of This Document</a></h2>
-	<p>This document is an experimental draft specification.</p>
+	</section>
+
+	<section id="conformance">
 	</section>
 
 	<section id="context">
-	<h2><a href="#context">Context</a></h2>
+	<h2>Context</h2>
 	<p><a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file: <a href="https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json">https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json</a></p>
-	<p>This context file is expected to be used in <code>@context</code> following the Security Vocabulary context (<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>). i.e.:</p>
+	<p>This context file is expected to be used in <code>@context</code> following the [[SECURITY-VOCABULARY]] context (<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>). i.e.:</p>
 	<pre>
 {
   "@context": [
@@ -44,7 +112,7 @@ section:target {
 	</section>
 
 	<section id="cacao-zcap-mapping">
-	<h2><a href="#cacao-zcap-mapping">CACAO-ZCAP Mapping</a></h2>
+	<h2>CACAO-ZCAP Mapping</h2>
 	<table class="mapping-table">
 		<thead>
 			<tr>
@@ -206,42 +274,40 @@ section:target {
 	</table>
 
 	<section id="id-cid-uuid-mapping">
-	<h3><a href="#id-cid-uuid-mapping">id CID UUID mapping</a></h3>
-	<p>The CACAO is serialized using
-	<a href="https://ipld.io/specs/codecs/dag-cbor/">DAG-CBOR</a>.
+	<h3>id CID UUID mapping</h3>
+	<p>The CACAO is serialized using [[DAG-CBOR]].
 	A SHA-256 hash is computed over this serialization.
 	The last 16 bytes of the hash (dropping the initial 16)
-	is used as "pseudo-random" input to a
-	<a href="https://datatracker.ietf.org/doc/html/rfc4122#section-4.4">RFC 4122 v4 UUID</a>.
+	is used as "pseudo-random" input to a [[RFC4122]] v4 UUID.
 	This UUID is represented as a URN by prefixing it with "urn:uuid:".
 	This URN is used as the id of the delegation object.</p>
 	</section>
 
 	<section id="iss-vm-mapping">
-	<h3><a href="#iss-vm-mapping">issuer-verificationMethod mapping</a></h3>
-	<p>The CACAO payload issuer property (<code>p.iss</code>) is defined by the <a href="https://github.com/ChainAgnostic/CAIPs/blob/8fdb5bfd1bdf15c9daf8aacfbcc423533764dfe9/CAIPs/caip-draft_cacao.md#container-format">CACAO CAIP</a> to be a <a href="https://github.com/w3c-ccg/did-pkh/blob/ea93b0a5e0e8b54e572f3a6ca5a294f147901d2d/did-pkh-method-draft.md">did:pkh</a> DID. The proof <a href="https://www.w3.org/TR/did-core/#dfn-verificationmethod"><code>verificationMethod</code></a> property is expected to be a <a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL</a> resolving to a <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-methods">verification method</a>.
+	<h3>issuer-verificationMethod mapping</h3>
+	<p>The CACAO payload issuer property (<code>p.iss</code>) is defined by [[CACAO]] to be a [[DID-PKH]] DID. The proof <a href="https://www.w3.org/TR/did-core/#dfn-verificationmethod"><code>verificationMethod</code></a> property is expected to be a <a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL</a> resolving to a <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-methods">verification method</a>.
 	CACAO-ZCAP converts between these two fields by assuming that the issuer DID has a <em>default verification method</em>, that the CACAO signature is created using the <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-material">verification material</a> of that <em>default verification method</em>, and that the <em>default verification method</em> allows creating a proof of type <a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>.</p>
 	</section>
 
 	<section id="root-zcap-mapping">
-	<h3><a href="#root-zcap-mapping">Root ZCAP mapping</a></h3>
+	<h3>Root ZCAP mapping</h3>
 	<p>The first value of the CACAO payload resources array is used as the invocation target URI, that is the value of the zcap delegation's <code>invocationTarget</code> property. The invocation target URI is encoded into a root zcap URN to become the root capability id. The root zcap URN is constructed as the concatenation of <code>"urn:zcap:root:"</code> with <code>encodeURIComponent(invocationTarget)</code>. To transform the root zcap URN to the invocation target URI, the prefix <code>"urn:zcap:root:"</code> is removed and the remaining value is URL-decoded to return the invocation target id.</p>
 	</section>
 
 	<section id="intermediate-zcap-mapping">
-	<h3><a href="#intermediate-zcap-mapping">Intermediate ZCAP mapping</a></h3>
+	<h3>Intermediate ZCAP mapping</h3>
 	<p>If the proof <code>capabilityChain</code> array / CACAO resources array (<code>p.resources</code>) contain more than two elements,
 	the intermediate elements are passed through as URIs.</p>
 	</section>
 
 	<section id="previous-zcap-mapping">
-	<h3><a href="#previous-zcap-mapping">Previous ZCAP mapping</a></h3>
-	<p>The last value of the proof <code>capabilityChain</code> array / CACAO resources array (<code>p.resources</code>) represents the previous delegation. If the previous delegation is the root delegation, the <code>capabilityChain</code> array contains only the root delegation id, as a single value. If the previous delegation is a non-root delegation, the last value of the proof <code>capabilityChain</code> array is the previous delegation embedded as an object. The embedded previous delegation is represented in the last value of the CACAO resources array (<code>p.resources</code>) as a <a href="https://datatracker.ietf.org/doc/html/rfc2397">Data URI</a> containing the Base64-encoded JSON object serialized with <a href="https://www.rfc-editor.org/rfc/rfc8785">JSON Canonicalization Scheme (JCS)</a>.</p>
+	<h3>Previous ZCAP mapping</h3>
+	<p>The last value of the proof <code>capabilityChain</code> array / CACAO resources array (<code>p.resources</code>) represents the previous delegation. If the previous delegation is the root delegation, the <code>capabilityChain</code> array contains only the root delegation id, as a single value. If the previous delegation is a non-root delegation, the last value of the proof <code>capabilityChain</code> array is the previous delegation embedded as an object. The embedded previous delegation is represented in the last value of the CACAO resources array (<code>p.resources</code>) as a [[RFC2397]] Data URI containing the Base64-encoded JSON object serialized with [[RFC8785]] JSON Canonicalization Scheme (JCS).</p>
 	</section>
 
 	<section id="signature-proof-value-mapping">
-	<h3><a href="#signature-proof-value-mapping">signature-proofValue mapping</a></h3>
-	<p>In CACAO, the signature is represented with an <a href="https://ipld.io/docs/schemas/features/typekinds/">IPLD</a> <em>bytes</em> type. In ZCAP and data integrity proofs, the signature is typically represented in a string in the <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-proofvalue">proofValue</a> property of the proof object. CACAO-ZCAP encodes the signature in the proofValue property using <a href="https://datatracker.ietf.org/doc/html/draft-multiformats-multibase">multibase</a>.</p>
+	<h3>signature-proofValue mapping</h3>
+	<p>In CACAO, the signature is represented with an <a href="https://ipld.io/docs/schemas/features/typekinds/">IPLD</a> <em>bytes</em> type. In ZCAP and data integrity proofs, the signature is typically represented in a string in the <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-proofvalue">proofValue</a> property of the proof object. CACAO-ZCAP encodes the signature in the proofValue property using [[MULTIBASE]].</p>
 	</section>
 
 	<section id="statement-actions-mapping">
@@ -267,11 +333,11 @@ substatement     = *( reserved / unreserved / " " )
 	</section>
 
 	<section id="terms">
-	<h2><a href="#terms">Terms</a></h2>
+	<h2>Terms</h2>
 	<p>This document defines the following terms, in the namespace <code>https://demo.didkit.dev/2022/cacao-zcap/#</code>.</p>
 
 	<section id="CacaoZcap2022">
-	<h3><a href="#CacaoZcap2022">CacaoZcap2022</a></h3>
+	<h3>CacaoZcap2022</h3>
 	<p>A CACAO interpreted as an authorization capability delegation.</p>
 	<p>The <code>proof</code> property should be an object of type <a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>. The <code>invocationTarget</code> property should be the URL to which an entity is being authorized access.</p>
         <dl>
@@ -292,7 +358,7 @@ substatement     = *( reserved / unreserved / " " )
 	</section>
 
 	<section id="CacaoZcapProof2022">
-	<h3><a href="#CacaoZcapProof2022">CacaoZcapProof2022</a></h3>
+	<h3>CacaoZcapProof2022</h3>
 	<p>A <a href="https://w3c-ccg.github.io/data-integrity-spec/#proofs">data integrity proof</a> over an authorization capability delegation document (<a href="#CacaoZcap2022">CacaoZcap2022</a>), together representing a CACAO.</p>
         <dl>
 		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
@@ -314,7 +380,7 @@ substatement     = *( reserved / unreserved / " " )
 	</section>
 
 	<section id="cacaoPayloadType">
-	<h3><a href="#cacaoPayloadType">cacaoPayloadType</a></h3>
+	<h3>cacaoPayloadType</h3>
 	<p>CACAO payload format type (CACAO header "t" value). e.g. "eip4361".</p>
         <dl>
 		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
@@ -325,7 +391,7 @@ substatement     = *( reserved / unreserved / " " )
 	</section>
 
 	<section id="cacaoSignatureType">
-	<h3><a href="#cacaoSignatureType">cacaoSignatureType</a></h3>
+	<h3>cacaoSignatureType</h3>
 	<p>CACAO signature type (CACAO signature "t" value). e.g. "eip191" or "eip1271".</p>
         <dl>
 		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
@@ -336,7 +402,7 @@ substatement     = *( reserved / unreserved / " " )
 	</section>
 
 	<section id="cacaoZcapSubstatement">
-	<h3><a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a></h3>
+	<h3>cacaoZcapSubstatement</h3>
 	<p>CACAO substatement, parsed from the CACAO payload "statement" value
 	according to the <a href="#statement-actions-mapping">statement-actions
 	mapping</a>.</p>
@@ -349,7 +415,7 @@ substatement     = *( reserved / unreserved / " " )
 	</section>
 
 	<section id="cacaoRequestId">
-	<h3><a href="#cacaoRequestId">cacaoRequestId</a></h3>
+	<h3>cacaoRequestId</h3>
 	<p>CACAO request ID (CACAO payload "requestId" value).</p>
         <dl>
 		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
@@ -359,17 +425,6 @@ substatement     = *( reserved / unreserved / " " )
 	</dl>
 	</section>
 
-	</section>
-
-	<section id="references">
-	<h2><a href="#references">References</a></h2>
-	<ul>
-		<li><a href="https://github.com/ChainAgnostic/CAIPs/blob/8fdb5bfd1bdf15c9daf8aacfbcc423533764dfe9/CAIPs/caip-draft_cacao.md">CACAO: Chain Agnostic CApability Object</a></li>
-		<li><a href="https://w3c-ccg.github.io/zcap-spec/">Authorization Capabilities for Linked Data v0.3</a> (<a href="https://github.com/w3c-ccg/zcap-spec/blob/79244f3dab64e6486cb2212705f7f104bd7288a8/index.html">79244f3dab</a>)</li>
-		<li><a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity 1.0</a> (<a href="https://github.com/w3c-ccg/data-integrity-spec/blob/22263882b1cab0aee153fe3a0a3684da36dde36f/index.html">22263882b1</a>)</li>
-		<li><a href="https://w3c-ccg.github.io/security-vocab/">The Security Vocabulary</a> (<a href="https://github.com/w3c-ccg/security-vocab/blob/8152248f69a030ca3ca9ee5a66b8df70f42fece5/index.html">8152248f69</a>)</li>
-		<li><a href="https://datatracker.ietf.org/doc/html/draft-multiformats-multibase">The Multibase Data Format</a></li>
-	</ul>
 	</section>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -1,106 +1,113 @@
 <!doctype html>
 <html>
 <head>
-	<title>CACAO-ZCAP</title>
-	<meta charset=utf-8>
-	<style>
+  <title>CACAO-ZCAP</title>
+  <meta charset=utf-8>
+  <style>
 .mapping-table td:nth-child(2) {
-	text-align: center;
+  text-align: center;
 }
-	</style>
-	<script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
-	<script class="remove">
-	  // https://respec.org/docs/
-	  const respecConfig = {
-	    shortName: "cacao-zcap",
-	    specStatus: "unofficial",
-	    edDraftURI: "https://demo.didkit.dev/2022/cacao-zcap/",
-	    editors: [
-	      {
-		name: "Charles E. Lehner", url: "https://www.w3.org/wiki/User:Cel",
-		company: "Spruce", companyURL: "https://spruceid.com/",
-		w3cid: 124982
-	      }
-	    ],
-	    subtitle: "Chain-Agnostic CApability Objects (CACAOs) as Authorization Capabilities (zCaps)",
-	    group: "credentials",
-	    wgPublicList: "public-credentials",
-	    github: {
-	      repoURL: "spruceid/cacao-zcap",
-	      branch: "main"
-	    },
-	    localBiblio: {
-	      "MULTIBASE": {
-		title: "The Multibase Encoding Scheme",
-		date: "February 2022",
-		href: "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-05",
-		authors: ["Juan Benet", "Manu Sporny"],
-		status: "Internet-Draft",
-		publisher: "IETF"
-	      },
-	      "SECURITY-VOCABULARY": {
-		title: "Security Linked Data Vocabulary",
-		href: "https://w3id.org/security",
-		authors: ["Manu Sporny", "David Longley"],
-		status: "CGDRAFT",
-		publisher: "Web Payments Community Group",
-	      },
-	      "DATA-INTEGRITY": {
-		title: "Data Integrity",
-		href: "https://w3c-ccg.github.io/data-integrity-spec/",
-		authors: ["David Longley", "Manu Sporny"],
-		status: "CGDRAFT",
-		publisher: "Credentials Community Group",
-	      },
-	      "ZCAP": {
-		title:    "Authorization Capabilities for Linked Data v0.3",
-		href:     "https://w3c-ccg.github.io/zcap-spec/",
-		status:   "CGDRAFT",
-		authors: ["Christopher Lemmer Webber", "Manu Sporny", "Mark S. Miller"],
-		publisher:  "Credentials Community Group"
-	      },
-	      "CACAO": {
-		title: "CACAO: Chain Agnostic CApability Object",
-		href: "https://github.com/ChainAgnostic/CAIPs/blob/91aaaff73038c2629ff11b88c2209f61521d8ece/CAIPs/caip-74.md",
-		authors: ["Sergey Ukustov"],
-                publisher: "CASA",
-		date: "March 2022"
-	      },
-	      "DAG-CBOR": {
-	        title: "DAG-CBOR: CBOR IPLD format",
-		href: "https://ipld.io/specs/codecs/dag-cbor/spec/",
-		authors: ["Rod Vagg", "Volker Mische", "Mikeal Rogers"],
-		status: "Descriptive - Draft",
-                publisher: "IPLD",
-		date: "August 2019"
-	      },
-	      "DID-PKH": {
-	        title: "The did:pkh Method",
-                href: "https://github.com/w3c-ccg/did-pkh/blob/ea93b0a5e0e8b54e572f3a6ca5a294f147901d2d/did-pkh-method-draft.md",
-		authors: ["Wayne Chang", "Charles Lehner", "Juan Caballero", "Joel Thorstensson"],
-                status: "W3C Community Group Draft",
-                publisher: "W3C Credentials Community Group",
-		date: "February 2022"
-	      }
-	    }
-	  };
-	</script>
+  </style>
+  <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+  <script class="remove">
+  // https://respec.org/docs/
+  const respecConfig = {
+    shortName: "cacao-zcap",
+    specStatus: "unofficial",
+    edDraftURI: "https://demo.didkit.dev/2022/cacao-zcap/",
+    editors: [
+      {
+        name: "Charles E. Lehner", url: "https://www.w3.org/wiki/User:Cel",
+        company: "Spruce", companyURL: "https://spruceid.com/",
+        w3cid: 124982
+      }
+    ],
+    subtitle: "Chain-Agnostic CApability Objects (CACAOs) as Authorization Capabilities (zCaps)",
+    group: "credentials",
+    wgPublicList: "public-credentials",
+    github: {
+      repoURL: "spruceid/cacao-zcap",
+      branch: "main"
+    },
+    localBiblio: {
+      "MULTIBASE": {
+        title: "The Multibase Encoding Scheme",
+        date: "February 2022",
+        href: "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-05",
+        authors: ["Juan Benet", "Manu Sporny"],
+        status: "Internet-Draft",
+        publisher: "IETF"
+      },
+      "SECURITY-VOCABULARY": {
+        title: "Security Linked Data Vocabulary",
+        href: "https://w3id.org/security",
+        authors: ["Manu Sporny", "David Longley"],
+        status: "CGDRAFT",
+        publisher: "Web Payments Community Group",
+      },
+      "DATA-INTEGRITY": {
+        title: "Data Integrity",
+        href: "https://w3c-ccg.github.io/data-integrity-spec/",
+        authors: ["David Longley", "Manu Sporny"],
+        status: "CGDRAFT",
+        publisher: "Credentials Community Group",
+      },
+      "ZCAP": {
+        title:    "Authorization Capabilities for Linked Data v0.3",
+        href:     "https://w3c-ccg.github.io/zcap-spec/",
+        status:   "CGDRAFT",
+        authors: ["Christopher Lemmer Webber", "Manu Sporny", "Mark S. Miller"],
+        publisher:  "Credentials Community Group"
+      },
+      "CACAO": {
+        title: "CACAO: Chain Agnostic CApability Object",
+        href: "https://github.com/ChainAgnostic/CAIPs/blob/91aaaff73038c2629ff11b88c2209f61521d8ece/CAIPs/caip-74.md",
+        authors: ["Sergey Ukustov"],
+        publisher: "CASA",
+        date: "March 2022"
+      },
+      "DAG-CBOR": {
+        title: "DAG-CBOR: CBOR IPLD format",
+        href: "https://ipld.io/specs/codecs/dag-cbor/spec/",
+        authors: ["Rod Vagg", "Volker Mische", "Mikeal Rogers"],
+        status: "Descriptive - Draft",
+        publisher: "IPLD",
+        date: "August 2019"
+      },
+      "DID-PKH": {
+        title: "The did:pkh Method",
+        href: "https://github.com/w3c-ccg/did-pkh/blob/ea93b0a5e0e8b54e572f3a6ca5a294f147901d2d/did-pkh-method-draft.md",
+        authors: ["Wayne Chang", "Charles Lehner", "Juan Caballero", "Joel Thorstensson"],
+        status: "W3C Community Group Draft",
+        publisher: "W3C Credentials Community Group",
+        date: "February 2022"
+      }
+    }
+  };
+  </script>
 </head>
 <body>
-	<section id="abstract">
-	</section>
+  <section id="abstract">
+  </section>
 
-	<section id="sotd">
-	</section>
+  <section id="sotd">
+  </section>
 
-	<section id="conformance">
-	</section>
+  <section id="conformance">
+  </section>
 
-	<section id="context">
-	<h2>Context</h2>
-	<p><a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file: <a href="https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json">https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json</a></p>
-	<p>This context file is expected to be used in <code>@context</code> following the [[SECURITY-VOCABULARY]] context (<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>). i.e.:</p>
-	<pre>
+  <section id="context">
+    <h2>Context</h2>
+    <p>
+<a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file: <a
+href="https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json">https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json</a>
+    </p>
+    <p>
+This context file is expected to be used in <code>@context</code> following the
+[[SECURITY-VOCABULARY]] context
+(<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>). i.e.:
+    </p>
+    <pre>
 {
   "@context": [
     "https://w3id.org/security/v2",
@@ -108,212 +115,259 @@
   ],
   ...
 }
-	</pre>
-	</section>
+    </pre>
+  </section>
 
-	<section id="cacao-zcap-mapping">
-	<h2>CACAO-ZCAP Mapping</h2>
-	<table class="mapping-table">
-		<thead>
-			<tr>
-				<th>CACAO property</th>
-				<th>Relationship/Value</th>
-				<th>ZCAP property</th>
-				<th>Required?</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>h.t</td>
-				<td>=</td>
-				<td>cacaoPayloadType</td>
-				<td>yes</td>
-			</tr>
+  <section id="cacao-zcap-mapping">
+    <h2>CACAO-ZCAP Mapping</h2>
+    <table class="mapping-table">
+      <thead>
+        <tr>
+          <th>CACAO property</th>
+          <th>Relationship/Value</th>
+          <th>ZCAP property</th>
+          <th>Required?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>h.t</td>
+          <td>=</td>
+          <td>cacaoPayloadType</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.domain</td>
-				<td>=</td>
-				<td>proof.domain</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.domain</td>
+          <td>=</td>
+          <td>proof.domain</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.iss</td>
-				<td><a href="#iss-vm-mapping">DID &harr; DID URL</a></td>
-				<td>proof.verificationMethod</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.iss</td>
+          <td><a href="#iss-vm-mapping">DID &harr; DID URL</a></td>
+          <td>proof.verificationMethod</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.aud</td>
-				<td>=</td>
-				<td>invoker</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.aud</td>
+          <td>=</td>
+          <td>invoker</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.version</td>
-				<td>"1"</td>
-				<td>&ndash;</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.version</td>
+          <td>"1"</td>
+          <td>&ndash;</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>&ndash;</td>
-				<td><a href="#context">[...]</a></td>
-				<td>@context</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>&ndash;</td>
+          <td><a href="#context">[...]</a></td>
+          <td>@context</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>&ndash;</td>
-				<td>"<a href="#CacaoZcap2022">CacaoZcap2022</a>"</td>
-				<td>type</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>&ndash;</td>
+          <td>"<a href="#CacaoZcap2022">CacaoZcap2022</a>"</td>
+          <td>type</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>&ndash;</td>
-				<td>"<a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>"</td>
-				<td>proof.type</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>&ndash;</td>
+          <td>"<a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>"</td>
+          <td>proof.type</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.nonce</td>
-				<td>=</td>
-				<td>proof.nonce</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.nonce</td>
+          <td>=</td>
+          <td>proof.nonce</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.iat</td>
-				<td>=</td>
-				<td>proof.created</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.iat</td>
+          <td>=</td>
+          <td>proof.created</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.nbf</td>
-				<td>=</td>
-				<td>proof.validFrom</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.nbf</td>
+          <td>=</td>
+          <td>proof.validFrom</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>p.exp</td>
-				<td>=</td>
-				<td>expires</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.exp</td>
+          <td>=</td>
+          <td>expires</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>p.statement</td>
-				<td><a href="#statement-actions-mapping">statement-actions mapping</a></td>
-				<td>cacaoZcapSubstatement, allowedAction</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.statement</td>
+          <td><a href="#statement-actions-mapping">statement-actions mapping</a></td>
+          <td>cacaoZcapSubstatement, allowedAction</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>p.requestId</td>
-				<td>=</td>
-				<td>requestId</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.requestId</td>
+          <td>=</td>
+          <td>requestId</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>.</td>
-				<td><a href="#id-cid-uuid-mapping">CID &rarr;</a></td>
-				<td>id</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>.</td>
+          <td><a href="#id-cid-uuid-mapping">CID &rarr;</a></td>
+          <td>id</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>p.resources[0]</td>
-				<td>=</td>
-				<td>invocationTarget</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>p.resources[0]</td>
+          <td>=</td>
+          <td>invocationTarget</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>p.resources[0]</td>
-				<td><a href="#root-zcap-mapping">URL &harr; ZCAP Root URN</a></td>
-				<td>proof.capabilityChain[0]</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.resources[0]</td>
+          <td><a href="#root-zcap-mapping">URL &harr; ZCAP Root URN</a></td>
+          <td>proof.capabilityChain[0]</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>p.resources[1..n-2]</td>
-				<td><a href="#intermediate-zcap-mapping">=</a></td>
-				<td>proof.capabilityChain[1..n-2]</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.resources[1..n-2]</td>
+          <td><a href="#intermediate-zcap-mapping">=</a></td>
+          <td>proof.capabilityChain[1..n-2]</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>p.resources[n-1]</td>
-				<td><a href="#previous-zcap-mapping">Object &harr; Data URI</a></td>
-				<td>proof.capabilityChain[n-1]</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>p.resources[n-1]</td>
+          <td><a href="#previous-zcap-mapping">Object &harr; Data URI</a></td>
+          <td>proof.capabilityChain[n-1]</td>
+          <td>no</td>
+        </tr>
 
-			<tr>
-				<td>s.t</td>
-				<td>=</td>
-				<td>proof.cacaoSignatureType</td>
-				<td>yes</td>
-			</tr>
+        <tr>
+          <td>s.t</td>
+          <td>=</td>
+          <td>proof.cacaoSignatureType</td>
+          <td>yes</td>
+        </tr>
 
-			<tr>
-				<td>s.s</td>
-				<td><a href="#signature-proof-value-mapping">bytes &harr; multibase</a></td>
-				<td>proof.proofValue</td>
-				<td>no</td>
-			</tr>
+        <tr>
+          <td>s.s</td>
+          <td><a href="#signature-proof-value-mapping">bytes &harr; multibase</a></td>
+          <td>proof.proofValue</td>
+          <td>no</td>
+        </tr>
 
-		</tbody>
-	</table>
+      </tbody>
+    </table>
 
-	<section id="id-cid-uuid-mapping">
-	<h3>id CID UUID mapping</h3>
-	<p>The CACAO is serialized using [[DAG-CBOR]].
-	A SHA-256 hash is computed over this serialization.
-	The last 16 bytes of the hash (dropping the initial 16)
-	is used as "pseudo-random" input to a [[RFC4122]] v4 UUID.
-	This UUID is represented as a URN by prefixing it with "urn:uuid:".
-	This URN is used as the id of the delegation object.</p>
-	</section>
+    <section id="id-cid-uuid-mapping">
+      <h3>id CID UUID mapping</h3>
+      <p>
+The CACAO is serialized using [[DAG-CBOR]]. A SHA-256 hash is computed over
+this serialization. The last 16 bytes of the hash (dropping the initial 16) is
+used as "pseudo-random" input to a [[RFC4122]] v4 UUID. This UUID is
+represented as a URN by prefixing it with "urn:uuid:". This URN is used as the
+id of the delegation object.
+      </p>
+    </section>
 
-	<section id="iss-vm-mapping">
-	<h3>issuer-verificationMethod mapping</h3>
-	<p>The CACAO payload issuer property (<code>p.iss</code>) is defined by [[CACAO]] to be a [[DID-PKH]] DID. The proof <a href="https://www.w3.org/TR/did-core/#dfn-verificationmethod"><code>verificationMethod</code></a> property is expected to be a <a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL</a> resolving to a <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-methods">verification method</a>.
-	CACAO-ZCAP converts between these two fields by assuming that the issuer DID has a <em>default verification method</em>, that the CACAO signature is created using the <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-material">verification material</a> of that <em>default verification method</em>, and that the <em>default verification method</em> allows creating a proof of type <a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>.</p>
-	</section>
+    <section id="iss-vm-mapping">
+      <h3>issuer-verificationMethod mapping</h3>
+      <p>
+The CACAO payload issuer property (<code>p.iss</code>) is defined by [[CACAO]]
+to be a [[DID-PKH]] DID. The proof
+<a href="https://www.w3.org/TR/did-core/#dfn-verificationmethod"><code>verificationMethod</code></a>
+property is expected to be a
+<a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL</a> resolving to
+a <a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-methods">verification method</a>.
+CACAO-ZCAP converts between these two fields by assuming that the issuer DID
+has a <em>default verification method</em>, that the CACAO signature is created
+using the
+<a href="https://w3c-ccg.github.io/data-integrity-spec/#verification-material">verification material</a>
+of that <em>default verification method</em>, and that the
+<em>default verification method</em> allows creating a proof of type
+<a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>.
+      </p>
+    </section>
 
-	<section id="root-zcap-mapping">
-	<h3>Root ZCAP mapping</h3>
-	<p>The first value of the CACAO payload resources array is used as the invocation target URI, that is the value of the zcap delegation's <code>invocationTarget</code> property. The invocation target URI is encoded into a root zcap URN to become the root capability id. The root zcap URN is constructed as the concatenation of <code>"urn:zcap:root:"</code> with <code>encodeURIComponent(invocationTarget)</code>. To transform the root zcap URN to the invocation target URI, the prefix <code>"urn:zcap:root:"</code> is removed and the remaining value is URL-decoded to return the invocation target id.</p>
-	</section>
+    <section id="root-zcap-mapping">
+      <h3>Root ZCAP mapping</h3>
+      <p>
+The first value of the CACAO payload resources array is used as the invocation
+target URI, that is the value of the zcap delegation's
+<code>invocationTarget</code> property. The invocation target URI is encoded
+into a root zcap URN to become the root capability id. The root zcap URN is
+constructed as the concatenation of <code>"urn:zcap:root:"</code> with
+<code>encodeURIComponent(invocationTarget)</code>. To transform the root zcap
+URN to the invocation target URI, the prefix <code>"urn:zcap:root:"</code> is
+removed and the remaining value is URL-decoded to return the invocation target
+id.
+      </p>
+    </section>
 
-	<section id="intermediate-zcap-mapping">
-	<h3>Intermediate ZCAP mapping</h3>
-	<p>If the proof <code>capabilityChain</code> array / CACAO resources array (<code>p.resources</code>) contain more than two elements,
-	the intermediate elements are passed through as URIs.</p>
-	</section>
+    <section id="intermediate-zcap-mapping">
+      <h3>Intermediate ZCAP mapping</h3>
+      <p>
+If the proof <code>capabilityChain</code> array / CACAO resources array
+(<code>p.resources</code>) contain more than two elements, the intermediate
+elements are passed through as URIs.
+      </p>
+    </section>
 
-	<section id="previous-zcap-mapping">
-	<h3>Previous ZCAP mapping</h3>
-	<p>The last value of the proof <code>capabilityChain</code> array / CACAO resources array (<code>p.resources</code>) represents the previous delegation. If the previous delegation is the root delegation, the <code>capabilityChain</code> array contains only the root delegation id, as a single value. If the previous delegation is a non-root delegation, the last value of the proof <code>capabilityChain</code> array is the previous delegation embedded as an object. The embedded previous delegation is represented in the last value of the CACAO resources array (<code>p.resources</code>) as a [[RFC2397]] Data URI containing the Base64-encoded JSON object serialized with [[RFC8785]] JSON Canonicalization Scheme (JCS).</p>
-	</section>
+    <section id="previous-zcap-mapping">
+      <h3>Previous ZCAP mapping</h3>
+      <p>
+The last value of the proof <code>capabilityChain</code> array / CACAO
+resources array (<code>p.resources</code>) represents the previous delegation.
+If the previous delegation is the root delegation, the
+<code>capabilityChain</code> array contains only the root delegation id, as a
+single value. If the previous delegation is a non-root delegation, the last
+value of the proof <code>capabilityChain</code> array is the previous
+delegation embedded as an object. The embedded previous delegation is
+represented in the last value of the CACAO resources array
+(<code>p.resources</code>) as a [[RFC2397]] Data URI containing the
+Base64-encoded JSON object serialized with [[RFC8785]] JSON Canonicalization
+Scheme (JCS).
+      </p>
+    </section>
 
-	<section id="signature-proof-value-mapping">
-	<h3>signature-proofValue mapping</h3>
-	<p>In CACAO, the signature is represented with an <a href="https://ipld.io/docs/schemas/features/typekinds/">IPLD</a> <em>bytes</em> type. In ZCAP and data integrity proofs, the signature is typically represented in a string in the <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-proofvalue">proofValue</a> property of the proof object. CACAO-ZCAP encodes the signature in the proofValue property using [[MULTIBASE]].</p>
-	</section>
+    <section id="signature-proof-value-mapping">
+      <h3>signature-proofValue mapping</h3>
+      <p>
+In CACAO, the signature is represented with an
+<a href="https://ipld.io/docs/schemas/features/typekinds/">IPLD</a>
+<em>bytes</em> type. In ZCAP and data integrity proofs, the signature is
+typically represented in a string in the
+<a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-proofvalue">proofValue</a>
+property of the proof object. CACAO-ZCAP encodes the signature in the
+proofValue property using [[MULTIBASE]].
+      </p>
+    </section>
 
-	<section id="statement-actions-mapping">
-	<h3><a href="#statement-actions-mapping">statement-actions mapping</a></h3>
-	<p>The CACAO statement string MUST match the following ABNF (extending <a href="https://www.rfc-editor.org/rfc/rfc3986#appendix-A">RFC 3986</a>):</p>
-	<pre>
+    <section id="statement-actions-mapping">
+      <h3>statement-actions mapping</h3>
+      <p>The CACAO statement string MUST match the following ABNF (extending <a href="https://www.rfc-editor.org/rfc/rfc3986#appendix-A">RFC 3986</a>):</p>
+      <pre>
 statement        = stmt-noaction / stmt-action
 stmt-noaction    = "Authorize action" substmt-opt
 stmt-action      = "Authorize action (" actions ")" substmt-opt
@@ -322,110 +376,131 @@ actions          = action *( ", " action )
 action           = *( reserved / unreserved / " " )
 substatement     = *( reserved / unreserved / " " )
 	</pre>
-	<p>The <code>substatement</code> is the value of the <a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a> proof property if present.</p>
-	<p>The <code>action</code> values are represented in the proof's <code>allowedAction</code> property as follows:</p>
-	<ul>
-		<li><code>allowedAction</code> is omitted when the <code>stmt-noaction</code> production is matched.</li>
-		<li><code>allowedAction</code> is an array of <code>action</code> strings when the <code>stmt-actions</code> production is matched.</li>
-	</ul>
-	</section>
+        <p>The <code>substatement</code> is the value of the <a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a> proof property if present.</p>
+        <p>The <code>action</code> values are represented in the proof's <code>allowedAction</code> property as follows:</p>
+        <ul>
+          <li><code>allowedAction</code> is omitted when the <code>stmt-noaction</code> production is matched.</li>
+          <li><code>allowedAction</code> is an array of <code>action</code> strings when the <code>stmt-actions</code> production is matched.</li>
+        </ul>
+    </section>
 
-	</section>
+  </section>
 
-	<section id="terms">
-	<h2>Terms</h2>
-	<p>This document defines the following terms, in the namespace <code>https://demo.didkit.dev/2022/cacao-zcap/#</code>.</p>
+  <section id="terms">
+    <h2>Terms</h2>
+    <p>
+This document defines the following terms, in the namespace
+<code>https://demo.didkit.dev/2022/cacao-zcap/#</code>.
+    </p>
 
-	<section id="CacaoZcap2022">
-	<h3>CacaoZcap2022</h3>
-	<p>A CACAO interpreted as an authorization capability delegation.</p>
-	<p>The <code>proof</code> property should be an object of type <a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>. The <code>invocationTarget</code> property should be the URL to which an entity is being authorized access.</p>
-        <dl>
-		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
-		<dd>unstable</dd>
-		<dt>Expected properties</dt>
-		<dd>
-			<a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">type</a>,
-			<a href="https://w3id.org/security#parentCapability">parentCapability</a>,
-			<a href="https://w3id.org/security#invocationTarget">invocationTarget</a>,
-			<a href="https://w3id.org/security#expiration">expires</a>,
-			<a href="https://w3id.org/security#allowedAction">allowedAction</a>,
-			<a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a>,
-			<a href="#cacaoRequestId">cacaoRequestId</a>,
-			<a href="https://w3id.org/security#proof">proof</a>
-		</dd>
-        </dl>
-	</section>
+    <section id="CacaoZcap2022">
+      <h3>CacaoZcap2022</h3>
+      <p>
+A CACAO interpreted as an authorization capability delegation.
+      </p>
+      <p>
+The <code>proof</code> property should be an object of type
+<a href="#CacaoZcapProof2022">CacaoZcapProof2022</a>.
+The <code>invocationTarget</code> property should be the URL to which an entity
+is being authorized access.
+      </p>
+      <dl>
+        <dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
+        <dd>unstable</dd>
+        <dt>Expected properties</dt>
+        <dd>
+          <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">type</a>,
+          <a href="https://w3id.org/security#parentCapability">parentCapability</a>,
+          <a href="https://w3id.org/security#invocationTarget">invocationTarget</a>,
+          <a href="https://w3id.org/security#expiration">expires</a>,
+          <a href="https://w3id.org/security#allowedAction">allowedAction</a>,
+          <a href="#cacaoZcapSubstatement">cacaoZcapSubstatement</a>,
+          <a href="#cacaoRequestId">cacaoRequestId</a>,
+          <a href="https://w3id.org/security#proof">proof</a>
+        </dd>
+      </dl>
+    </section>
 
-	<section id="CacaoZcapProof2022">
-	<h3>CacaoZcapProof2022</h3>
-	<p>A <a href="https://w3c-ccg.github.io/data-integrity-spec/#proofs">data integrity proof</a> over an authorization capability delegation document (<a href="#CacaoZcap2022">CacaoZcap2022</a>), together representing a CACAO.</p>
-        <dl>
-		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
-		<dd>unstable</dd>
-		<dt>Expected properties</dt>
-		<dd>
-			<a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">type</a>,
-			<a href="http://purl.org/dc/terms/created">created</a>,
-			<a href="https://w3id.org/security#verificationMethod">verificationMethod</a>,
-			<a href="https://w3id.org/security#proofPurpose">proofPurpose</a>,
-			<a href="https://w3id.org/security#proofValue">proofValue</a>,
-			<a href="https://w3id.org/security#domain">domain</a>,
-			<a href="https://w3id.org/security#nonce">nonce</a>,
-			<a href="https://w3id.org/security#capabilityChain">capabilityChain</a>,
-			<a href="#cacaoPayloadType">cacaoPayloadType</a>,
-			<a href="#cacaoSignatureType">cacaoSignatureType</a>
-		</dd>
-        </dl>
-	</section>
+    <section id="CacaoZcapProof2022">
+      <h3>CacaoZcapProof2022</h3>
+      <p>
+A <a href="https://w3c-ccg.github.io/data-integrity-spec/#proofs">data
+integrity proof</a> over an authorization capability delegation document
+(<a href="#CacaoZcap2022">CacaoZcap2022</a>), together representing a CACAO.
+      </p>
+      <dl>
+        <dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
+        <dd>unstable</dd>
+        <dt>Expected properties</dt>
+        <dd>
+          <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">type</a>,
+          <a href="http://purl.org/dc/terms/created">created</a>,
+          <a href="https://w3id.org/security#verificationMethod">verificationMethod</a>,
+          <a href="https://w3id.org/security#proofPurpose">proofPurpose</a>,
+          <a href="https://w3id.org/security#proofValue">proofValue</a>,
+          <a href="https://w3id.org/security#domain">domain</a>,
+          <a href="https://w3id.org/security#nonce">nonce</a>,
+          <a href="https://w3id.org/security#capabilityChain">capabilityChain</a>,
+          <a href="#cacaoPayloadType">cacaoPayloadType</a>,
+          <a href="#cacaoSignatureType">cacaoSignatureType</a>
+        </dd>
+      </dl>
+    </section>
 
-	<section id="cacaoPayloadType">
-	<h3>cacaoPayloadType</h3>
-	<p>CACAO payload format type (CACAO header "t" value). e.g. "eip4361".</p>
-        <dl>
-		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
-		<dd>unstable</dd>
-		<dt>Expected type</dt>
-		<dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
-	</dl>
-	</section>
+    <section id="cacaoPayloadType">
+      <h3>cacaoPayloadType</h3>
+      <p>
+CACAO payload format type (CACAO header "t" value). e.g. "eip4361".
+      </p>
+      <dl>
+        <dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
+        <dd>unstable</dd>
+        <dt>Expected type</dt>
+        <dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
+      </dl>
+    </section>
 
-	<section id="cacaoSignatureType">
-	<h3>cacaoSignatureType</h3>
-	<p>CACAO signature type (CACAO signature "t" value). e.g. "eip191" or "eip1271".</p>
-        <dl>
-		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
-		<dd>unstable</dd>
-		<dt>Expected type</dt>
-		<dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
-	</dl>
-	</section>
+    <section id="cacaoSignatureType">
+      <h3>cacaoSignatureType</h3>
+      <p>
+CACAO signature type (CACAO signature "t" value). e.g. "eip191" or "eip1271".
+      </p>
+      <dl>
+        <dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
+        <dd>unstable</dd>
+        <dt>Expected type</dt>
+        <dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
+      </dl>
+    </section>
 
-	<section id="cacaoZcapSubstatement">
-	<h3>cacaoZcapSubstatement</h3>
-	<p>CACAO substatement, parsed from the CACAO payload "statement" value
-	according to the <a href="#statement-actions-mapping">statement-actions
-	mapping</a>.</p>
-        <dl>
-		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
-		<dd>unstable</dd>
-		<dt>Expected type</dt>
-		<dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
-	</dl>
-	</section>
+    <section id="cacaoZcapSubstatement">
+      <h3>cacaoZcapSubstatement</h3>
+      <p>
+CACAO substatement, parsed from the CACAO payload "statement" value according
+to the <a href="#statement-actions-mapping">statement-actions mapping</a>.
+      </p>
+      <dl>
+        <dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
+        <dd>unstable</dd>
+        <dt>Expected type</dt>
+        <dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
+      </dl>
+    </section>
 
-	<section id="cacaoRequestId">
-	<h3>cacaoRequestId</h3>
-	<p>CACAO request ID (CACAO payload "requestId" value).</p>
-        <dl>
-		<dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
-		<dd>unstable</dd>
-		<dt>Expected type</dt>
-		<dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
-	</dl>
-	</section>
+    <section id="cacaoRequestId">
+      <h3>cacaoRequestId</h3>
+      <p>
+CACAO request ID (CACAO payload "requestId" value).
+      </p>
+      <dl>
+        <dt><a href="https://www.w3.org/2003/06/sw-vocab-status/note.html#vocab">Status</a></dt>
+        <dd>unstable</dd>
+        <dt>Expected type</dt>
+        <dd><a href="https://www.w3.org/TR/xmlschema11-2/#string">xsd:string</a></dd>
+      </dl>
+    </section>
 
-	</section>
+  </section>
 
 </body>
 </html>


### PR DESCRIPTION
Convert the web page to use [Respec](https://respec.org/docs/) like other CG docs. Add some spec text.

Structure is adjusted, and references are improved.

Marking sections as normative vs. informative could still be improved. This currently defaults them all to normative.

Content changes are in 26486f996595446ec8e00c507a086641d2981a1c; indentation and spaces only are changed in cc1c84e070f8b23045eee91be4894c0ab73276d3.

License and readme content are imported in 720288b from the `cacao-zcap-rs` repo where they are being removed in https://github.com/spruceid/cacao-zcap-rs/pull/15.

Added Respec validation GitHub Action based on https://github.com/w3c/spec-prod/blob/main/docs/examples.md#run-as-a-validator-on-pull-requests

Preview: https://demo.didkit.dev/2022/04/21/cacao-zcap-pr-1.html