### PR TITLE
Fix cacaoZcapSubstatement term definition

### DIFF
--- a/contexts/v1.json
+++ b/contexts/v1.json
@@ -12,7 +12,7 @@
         "id": "@id",
         "type": "@type",
         "cacaoPayloadType": "https://demo.didkit.dev/2022/cacao-zcap/#cacaoPayloadType",
-        "cacaoSubstatement": "https://demo.didkit.dev/2022/cacao-zcap/#cacaoSubstatement",
+        "cacaoZcapSubstatement": "https://demo.didkit.dev/2022/cacao-zcap/#cacaoZcapSubstatement",
         "cacaoRequestId": "https://demo.didkit.dev/2022/cacao-zcap/#cacaoRequestId"
       }
     },


### PR DESCRIPTION
"cacaoSubstatement" in the context file should have been "cacaoZcapSubstatement" in #43. This PR fixes this mistake in the context file.