### PR TITLE
Update context URLs to use contexts/

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,13 +30,13 @@ section:target {
 
 	<section id="context">
 	<h2><a href="#context">Context</a></h2>
-	<p><a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file: <a href="https://demo.didkit.dev/2022/cacao-zcap/context/v1.json">https://demo.didkit.dev/2022/cacao-zcap/context/v1.json</a></p>
+	<p><a href="https://www.w3.org/TR/json-ld11/#dfn-context">JSON-LD Context</a> file: <a href="https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json">https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json</a></p>
 	<p>This context file is expected to be used in <code>@context</code> following the Security Vocabulary context (<a href="https://w3id.org/security/v2">https://w3id.org/security/v2</a>). i.e.:</p>
 	<pre>
 {
   "@context": [
     "https://w3id.org/security/v2",
-    "https://demo.didkit.dev/2022/cacao-zcap/context/v1.json"
+    "https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json"
   ],
   ...
 }


### PR DESCRIPTION
This updates the document to use `contexts/` instead of `context/` for the context file URL. This change matches the current repository layout. Using "contexts/" rather than "context/" is more conventional in other existing repos containing context files (e.g. [lds-ed25519-2020](https://github.com/w3c-ccg/lds-ed25519-2020/tree/main/contexts), [lds-jws2020](https://github.com/w3c-ccg/lds-jws2020/tree/master/docs), [did-resolution](https://github.com/w3c-ccg/did-resolution/tree/gh-pages/contexts)).